### PR TITLE
Add setup.py, to be installable via pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,13 @@ This supybot plugin keeps records of channel mode changes in a sqlite database a
 The plugin is used in various and large channels on Libera.Chat and others networks
 This version works with python 3
 
+## Install 
+
 Note that you may need a newer version of Limnoria than your distribution provides, and you may need to install from the Limnoria source code or from PyPI / `pip` to make it function.  (Currently requires Limnoria version `2018.04.14` or newer)
+
+You can install this plugin with: `pip3 install git+https://github.com/ncoevoet/ChanTracker.git`.
+(Or, with Limnoria versions older than 2020.05.08: `git clone https://github.com/ncoevoet/ChanTracker.git` in your bot's `plugins/` directory.)
+Then, `@load ChanTracker`.
 
 ## Commands ##
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,13 @@
+import os
+import sys
+
+from supybot.setup import plugin_setup
+
+# Workaround pip changing the name of the root directory
+(parent, dir_) = os.path.split(os.path.dirname(__file__))
+sys.path.insert(0, parent)
+sys.modules["ChanTracker"] = __import__(dir_)
+
+plugin_setup(
+    'ChanTracker',
+)


### PR DESCRIPTION
This is a simpler way to install Limnoria plugin:
https://docs.limnoria.net/develop/plugin_distribution.html#via-pip-pypi

This will allow installing ChanTracker with this command:

```
pip3 install git+https://github.com/ncoevoet/ChanTracker.git
```

Before merging the PR, you can try it with:

```
pip3 install git+https://github.com/progval/ChanTracker.git@pipify
```